### PR TITLE
Chore: Interface update to 110207

### DIFF
--- a/AlreadyBoughtTracker/AlreadyBoughtTracker.toc
+++ b/AlreadyBoughtTracker/AlreadyBoughtTracker.toc
@@ -1,8 +1,8 @@
-## Interface: 110205
+## Interface: 110207
 ## Title: Already Bought Tracker
 ## Notes: Adds checkmarks or crosses to vendor items if already known/collected; can optionally dim them.
 ## Author: Eyara
-## Version: v0.3.3
+## Version: v0.3.4
 ## SavedVariables: ABT_Saved
 ## X-Curse-Project-ID: 1363230
 ## X-AddonProvider: github

--- a/AlreadyBoughtTracker/CHANGELOG.md
+++ b/AlreadyBoughtTracker/CHANGELOG.md
@@ -58,3 +58,7 @@
 
 ## v0.3.3
 - Bump version to v0.3.3
+
+## v0.3.4
+- Bump version to v0.3.4
+- Bump interface version to 110207


### PR DESCRIPTION
# Summary

Update the interface version to 110207 and bumped to v0.3.4

## Changes
- Only a minor update to match the new interface version

## Checklist
- [x] Uses Blizzard APIs first; tooltip scanning only as fallback
- [x] All user-facing text comes from `L` (Locales); no hardcoded strings
- [x] Settings use Blizzard Settings Framework with localized labels/tooltips
- [x] SavedVariables migrations added if any option was renamed/removed
- [x] Changelog updated and TOC version aligned (if releasing)
- [ ] CI green

## Testing notes
- WoW client locale: enUS
- WoW build / Interface version: 11.2.7 64978 110207
- Steps to validate: Addon is not outdated anymore

## Related issues / PRs
- N/A

## Release notes
- Bump version to v0.3.4
- Bump interface version to 110207
