### PR TITLE
Bug: Burst update lag

### DIFF
--- a/AlreadyBoughtTracker/AlreadyBoughtTracker.toc
+++ b/AlreadyBoughtTracker/AlreadyBoughtTracker.toc
@@ -1,8 +1,8 @@
-## Interface: 110207
+## Interface: 120000
 ## Title: Already Bought Tracker
 ## Notes: Adds checkmarks or crosses to vendor items if already known/collected; can optionally dim them.
 ## Author: Eyara
-## Version: v0.3.4
+## Version: v0.3.5
 ## SavedVariables: ABT_Saved
 ## X-Curse-Project-ID: 1363230
 ## X-AddonProvider: github

--- a/AlreadyBoughtTracker/CHANGELOG.md
+++ b/AlreadyBoughtTracker/CHANGELOG.md
@@ -62,3 +62,7 @@
 ## v0.3.4
 - Bump version to v0.3.4
 - Bump interface version to 110207
+
+## v0.3.5
+- Bump interface version to 120000
+- Fix: reduce merchant update burst frequency and add debounce to eliminate lag when buying/selling with other addons

--- a/AlreadyBoughtTracker/Core.lua
+++ b/AlreadyBoughtTracker/Core.lua
@@ -452,10 +452,13 @@ end
 
 local function ABT_ScheduleUpdateBurst()
   if not MerchantFrame or not MerchantFrame:IsShown() then return end
-  local delays = {0, 0.05, 0.1, 0.2, 0.35}
+  if ABT.updateScheduled then return end
+  ABT.updateScheduled = true
+  local delays = {0, 0.15}
   for _, d in ipairs(delays) do
     C_Timer.After(d, UpdateMerchant)
   end
+  C_Timer.After(0.25, function() ABT.updateScheduled = false end)
 end
 
 ABT.settingsRegistered = ABT.settingsRegistered or false


### PR DESCRIPTION
# Summary

This PR adds Midnight pre-patch compatibility and fixes a critical lag issue when using the addon alongside other transaction-heavy addons like Profession Shopping List.

## Changes
- Updated Interface version 120000
- Bumped addon version to v0.3.5
- Optimized merchant update burst mechanism: reduced from 5 rapid updates (0, 50, 100, 200, 350ms) to 2 spaced updates (0, 150ms)
- Added debounce flag (`ABT.updateScheduled`) to prevent overlapping update sequences during rapid vendor transactions

## Screenshots / Videos (optional)

N/A

## Checklist
- [x] Uses Blizzard APIs first; tooltip scanning only as fallback
- [x] All user-facing text comes from `L` (Locales); no hardcoded strings
- [x] Settings use Blizzard Settings Framework with localized labels/tooltips
- [x] SavedVariables migrations added if any option was renamed/removed
- [x] Changelog updated and TOC version aligned (if releasing)
- [ ] CI green

## Testing notes
- WoW client locale: enUS
- WoW build / Interface version: 12.0.0 65655 120000
- Steps to validate:
  1. Load addon
  2. Open any vendor UI
  3. Verify overlays (checkmarks/crosses) display correctly
  4. Test with Profession Shopping List addon installed
  5. Verify no lag during rapid buying/selling transactions
  6. Confirm Settings panel loads correctly

## Related issues / PRs
- Fixes #7 

## Release notes
- Bump interface version to 120000
- Fix: reduce merchant update burst frequency and add debounce to eliminate lag when buying/selling with other addons
